### PR TITLE
Don't crash when we find an event with no PID

### DIFF
--- a/parseSchedule.py
+++ b/parseSchedule.py
@@ -52,10 +52,13 @@ def main():
         start = event['start'].get('dateTime', event['start'].get('date'))
         end = event['end'].get('dateTime', event['end'].get('date'))
         match = re.search(r"PID:([A-z0-9\-]+)",event['description'])
-        pid = match.group(1)
-        expected_file_name = dateutil.parser.isoparse(start).strftime('%Y%m%d_%H%M') + "_" + pid.lower()
-        if "TYPE:RECORDED" in event['description']:    
-            schedule_content = schedule_content + "\"" + start + "\",\"" + end + "\",\"" + pid + "\",\"" + expected_file_name + "\",\"" + event['summary'] + "\"\n"
+        if not match:
+            print('No PID for event ', event['summary'])
+        else:
+            pid = match.group(1)
+            expected_file_name = dateutil.parser.isoparse(start).strftime('%Y%m%d_%H%M') + "_" + pid.lower()
+            if "TYPE:RECORDED" in event['description']:    
+                schedule_content = schedule_content + "\"" + start + "\",\"" + end + "\",\"" + pid + "\",\"" + expected_file_name + "\",\"" + event['summary'] + "\"\n"
     
     cron = open("/home/ubuntu/schedule.csv","w")
     cron.write(schedule_content)


### PR DESCRIPTION
Occasionally we get a schedule entry with no PID (or one we can't parse).

In those situations, don't crash out entirely - we still want to get the schedule for those events that are correctly specified. Log it (so we can find the offending event), but continue onwards.